### PR TITLE
HOT-15: Add app description subtitle to landing page

### DIFF
--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -85,7 +85,7 @@ export const Landing = () => {
                 {/* .main-title */}
                 <Typography
                     variant='h1'
-                    sx={{ fontSize: '6vw', color: WHITE, fontWeight: 'bold', lineHeight: 1.1 }}
+                    sx={{ fontSize: '6vw', color: WHITE, fontWeight: 'bold', lineHeight: 1.1, mb: '8px' }}
                 >
                   HotSpotr
                 </Typography>
@@ -95,7 +95,15 @@ export const Landing = () => {
                     variant='body1'
                     sx={{ fontSize: '1.5vw', color: WHITE }}
                 >
-                  Locate the low hanging fruit
+                  Where should you open?
+                </Typography>
+
+                {/* .sub-subtitle */}
+                <Typography
+                    variant='body2'
+                    sx={{ fontSize: '1.2vw', color: WHITE, maxWidth: '400px' }}
+                >
+                  Heatmap-powered insights on demographics, income, and competition for any US city.
                 </Typography>
 
                 {/* .button-group */}


### PR DESCRIPTION
### **Summary**
Replaces the original tagline "Locate the low hanging fruit" with a two-line value proposition that leads with the user's core question and highlights the heatmap differentiator.

### **Changes**
Landing.js

Replaced 'Locate the low hanging fruit' with 'Where should you open?' as the primary tagline
Added subtitle: 'Heatmap-powered insights on demographics, income, and competition for any US city.'
Added maxWidth constraint on subtitle Typography to prevent overflow at smaller viewports


### **Motivation**
The original tagline was memorable but abstract — a first-time visitor couldn't immediately understand what the product does. The new copy leads with the user's primary question ("Where should you open?") and explicitly mentions heatmaps, which is the core differentiator vs. manual research or enterprise GIS tools.

**Testing**

 Landing page renders with updated tagline and subtitle
 Subtitle wraps correctly and does not overflow at smaller viewports