### PR TITLE
Add first name and last name to user

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  'config': path.resolve('config', 'config.js'),
+  'models-path': path.resolve('models'),
+  'seeders-path': path.resolve('seeders'),
+  'migrations-path': path.resolve('migrations')
+};
+

--- a/README.md
+++ b/README.md
@@ -35,9 +35,28 @@ View the deployed application https://hotspotr.herokuapp.com/
 
 4. Set up your `.env` file with:
    - `SESSION_SECRET` - Random string for session encryption
-   - `REDIS_URL` - Redis connection URL
+   - `REDIS_URL` - Redis connection URL (default: `redis://localhost:6379`)
    - `REACT_APP_GOOGLE_API_KEY` - Google Maps API key
-   - Database credentials
+   - Database credentials (MySQL)
+
+5. Run database migrations:
+   ```bash
+   npx sequelize-cli db:migrate
+   ```
+
+### Services Required
+
+Make sure the following services are running:
+
+```bash
+# Redis (for session storage)
+redis-server
+
+# MySQL (for database)
+mysql.server start  # macOS
+# or
+sudo service mysql start  # Linux
+```
 
 ### Development
 
@@ -45,7 +64,7 @@ View the deployed application https://hotspotr.herokuapp.com/
 npm run dev
 ```
 
-This runs both the Express server and React client in development mode.
+This runs both the Express server (port 3001) and React client (port 3000) in development mode.
 
 ### Testing
 
@@ -60,16 +79,124 @@ npm run build
 npm start
 ```
 
+## Features
+
+### User Authentication
+- **Email/Password authentication** with Passport.js
+- **Optional name fields** - firstName and lastName can be provided during signup
+- **Session persistence** - Users stay logged in across page refreshes
+- **Secure password storage** - Bcrypt hashing with salt level 8
+- **Redis-backed sessions** - Fast, scalable session management
+
+### User Signup/Login
+**Signup form includes:**
+- First Name (optional)
+- Last Name (optional)
+- Email (required)
+- Password (required, min 6 characters)
+
+**Login form includes:**
+- Email (required)
+- Password (required)
+
+### Dashboard Features
+- Personalized welcome message with user's name or email
+- Target industry selection
+- Target location selection
+- Demographics analysis
+- Competition heatmap visualization
+- Google Maps integration
+
+## Database
+
+### User Model Schema
+```javascript
+{
+  id: INTEGER (primary key),
+  firstName: STRING (optional, max 50 characters),
+  lastName: STRING (optional, max 50 characters),
+  localemail: STRING (required, unique, validated as email),
+  localpassword: STRING (required, bcrypt hashed),
+  createdAt: DATE,
+  updatedAt: DATE
+}
+```
+
+### Managing Migrations
+
+Run migrations:
+```bash
+npx sequelize-cli db:migrate
+```
+
+Rollback last migration:
+```bash
+npx sequelize-cli db:migrate:undo
+```
+
+## API Endpoints
+
+### Authentication
+- `POST /signup` - Create new user account
+- `POST /login` - Authenticate user
+- `GET /logout` - End user session
+- `GET /api/user/current` - Get current logged-in user info
+- `GET /dashboard` - Check if user is authenticated
+
+### Application
+- `POST /call` - Google Places API search
+
 ## Security
 
 This application implements multiple security measures including:
-- Bcrypt password hashing (salt level 8)
-- Redis-backed sessions with HttpOnly cookies
-- Input validation on all authentication endpoints
-- Protection against session hijacking
-- Password logging prevention
+- **Bcrypt password hashing** (salt level 8)
+- **Redis-backed sessions** with HttpOnly cookies
+- **Input validation** on all authentication endpoints (express-validator)
+- **Protection against session hijacking**
+- **Password logging prevention** (bodyBlacklist in request logging)
+- **Passwords never stored in client state** (Redux only stores safe user data)
+- **CORS protection** with configurable origins
+- **Separate validation rules** for login and signup
 
 For detailed security information, see [docs/SECURITY.md](docs/SECURITY.md).
+
+## Troubleshooting
+
+### Common Issues
+
+**Login 500 Error:**
+- Ensure Redis is running: `redis-cli ping` should return `PONG`
+- Check database connection settings in `.env`
+- Verify all dependencies are installed
+
+**User data undefined:**
+- User data is loaded automatically on Dashboard mount
+- Check browser console for API errors
+- Verify `/api/user/current` endpoint is accessible
+
+**Database migration errors:**
+- Ensure MySQL is running
+- Verify database credentials in `config/config.js`
+- Check that `.sequelizerc` file exists in root directory
+
+## Tech Stack
+
+### Backend
+- Node.js / Express
+- Sequelize ORM
+- MySQL database
+- Redis (session store)
+- Passport.js (authentication)
+- Bcryptjs (password hashing)
+- Express-validator (input validation)
+
+### Frontend
+- React
+- Redux (state management)
+- Material-UI (MUI)
+- React Router
+- Google Maps API
+- Axios (HTTP client)
 
 ## License
 

--- a/client/src/actions/actionCreators.js
+++ b/client/src/actions/actionCreators.js
@@ -11,3 +11,17 @@ export const login = user => {
     payload: user
   }
 }
+
+export const setUser = user => {
+  return {
+    type: 'SET_USER',
+    payload: user
+  }
+}
+
+export const logout = () => {
+  return {
+    type: 'LOGOUT'
+  }
+}
+

--- a/client/src/components/AuthModal.js
+++ b/client/src/components/AuthModal.js
@@ -26,6 +26,8 @@ export const AuthModal = ({ clickedButton, activeModal, toggleModal }) => {
 
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [firstName, setFirstName] = useState('');
+    const [lastName, setLastName] = useState('');
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const [error, setError] = useState('');
     const dispatch = useDispatch();
@@ -34,10 +36,12 @@ export const AuthModal = ({ clickedButton, activeModal, toggleModal }) => {
         const { name, value } = event.target;
         if (name === 'email') setEmail(value);
         if (name === 'password') setPassword(value);
+        if (name === 'firstName') setFirstName(value);
+        if (name === 'lastName') setLastName(value);
     };
 
     const handleSignup = async () => {
-        const res = await userSignUp({ email, password });
+        const res = await userSignUp({ firstName, lastName, email, password });
         dispatch(signup(res));
         if (res) setIsLoggedIn(true);
     };
@@ -65,6 +69,8 @@ export const AuthModal = ({ clickedButton, activeModal, toggleModal }) => {
           }
           setEmail('');
           setPassword('');
+          setFirstName('');
+          setLastName('');
           toggleModal();
         } catch (err) {
           console.error(`${clickedButton} error:`, err);
@@ -116,6 +122,49 @@ export const AuthModal = ({ clickedButton, activeModal, toggleModal }) => {
                 <Alert severity='error' onClose={() => setError('')}>
                   {error}
                 </Alert>
+            )}
+
+            {/* First Name and Last Name fields - only show for Sign Up (optional) */}
+            {clickedButton === 'Sign Up' && (
+              <>
+                <TextField
+                    label='First Name'
+                    type='text'
+                    name='firstName'
+                    value={firstName}
+                    onChange={handleInputChange}
+                    fullWidth
+                    variant='outlined'
+                    size='small'
+                    sx={{
+                        '& .MuiOutlinedInput-root': { bgcolor: WHITE, borderRadius: '8px' },
+                        '& .MuiInputLabel-root': { color: BROWN },
+                        '& .MuiInputLabel-root.Mui-focused': { color: BROWN },
+                        '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                            borderColor: BROWN,
+                        },
+                    }}
+                />
+
+                <TextField
+                    label='Last Name'
+                    type='text'
+                    name='lastName'
+                    value={lastName}
+                    onChange={handleInputChange}
+                    fullWidth
+                    variant='outlined'
+                    size='small'
+                    sx={{
+                        '& .MuiOutlinedInput-root': { bgcolor: WHITE, borderRadius: '8px' },
+                        '& .MuiInputLabel-root': { color: BROWN },
+                        '& .MuiInputLabel-root.Mui-focused': { color: BROWN },
+                        '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                            borderColor: BROWN,
+                        },
+                    }}
+                />
+              </>
             )}
 
             {/* TextField replaces <label> + <input> */}

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Box, Button, Divider, Stack, Typography, useTheme } from '@mui/material';
 import BusinessIcon from '@mui/icons-material/Business';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
@@ -8,6 +8,7 @@ import MapIcon from '@mui/icons-material/Map';
 import LogoutIcon from '@mui/icons-material/Logout';
 import { ProgressBar } from './ProgressBar';
 import { userLogOut } from '../utils/API';
+import { logout } from '../actions/actionCreators';
 
 export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap }) => {
     const theme = useTheme();
@@ -57,15 +58,25 @@ export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleTogg
 
   const [completed, setCompleted] = useState(0);
   const user = useSelector((state) => state.user);
+  const dispatch = useDispatch();
 
   const handlers = { handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap };
 
   const handleLogOut = () => {
     userLogOut()
       .then(() => {
+        dispatch(logout());
         window.location.href = '/';
       })
       .catch((err) => console.error('Logout error:', err));
+  };
+
+  // Get display name for welcome message
+  const getDisplayName = () => {
+    if (!user) return 'Guest';
+    if (user.firstName) return user.firstName;
+    if (user.email) return user.email;
+    return 'Guest';
   };
 
   return (
@@ -95,11 +106,11 @@ export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleTogg
         }}
       >
         {/* .welcome-message */}
-        <Box sx={{ textAlign: 'center', color: WHITE, '& > *': { my: '10px' } }}>
+        <Box sx={{ textAlign: 'center', color: WHITE, width: '100%', '& > *': { my: '10px' } }}>
           <Typography variant='subtitle1' fontWeight='bold'>
-            {`Welcome, ${user?.email ?? 'Guest'}`}
+            {`Welcome, ${getDisplayName()}`}
           </Typography>
-          <Typography variant='body2'>Profile Progress</Typography>
+          <Typography variant='body2'>Analysis Progress</Typography>
           <ProgressBar completed={completed} />
         </Box>
       </Box>

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,11 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { useTheme } from '@mui/material'
 import { Sidebar } from '../components/Sidebar.js';
 import { SocialMedia } from '../components/SocialMedia.js';
 import { Maps } from '../components/Maps.js';
 import { Drawer, MenuItem, Box, Typography } from '@mui/material';
 import { IndustryForm, LocationForm, DemographicForm } from '../components/Forms';
-import { sendTest } from '../utils/API';
+import { sendTest, getCurrentUser } from '../utils/API';
+import { setUser } from '../actions/actionCreators';
 import { Logo2 } from '../components/Logo2.js';
 import { Footer } from '../components/Footer.js';
 
@@ -13,6 +15,7 @@ const DB_BG = 'https://res.cloudinary.com/willblake01/image/upload/v1538510014/h
 
 export const Dashboard = () => {
   const theme = useTheme();
+  const dispatch = useDispatch();
 
   const BROWN = theme.palette.secondary.main;
   const WHITE = theme.custom.white;
@@ -23,6 +26,15 @@ export const Dashboard = () => {
   const [location, setLocation] = useState('');
   const [demographic, setDemographic] = useState('');
   const [placesResults, setPlacesResults] = useState([]);
+
+  // Fetch current user on mount
+  useEffect(() => {
+    getCurrentUser().then((user) => {
+      if (user) {
+        dispatch(setUser(user));
+      }
+    });
+  }, [dispatch]);
 
   const handleClose = () => setOpen(false);
 

--- a/client/src/reducers/profile.js
+++ b/client/src/reducers/profile.js
@@ -1,24 +1,26 @@
 const SIGNUP = 'SIGNUP';
 const LOGIN = 'LOGIN';
+const SET_USER = 'SET_USER';
+const LOGOUT = 'LOGOUT';
 
 // A reducer takes in two things:
 
 // 1. The action (info about what happened)
 // 2. A copy of current state
-export const profile = (state = [], action) => {
+export const profile = (state = null, action) => {
     switch (action.type) {
         case SIGNUP:
-            return {
-                ...state,
-                email: action.payload.email,
-                password: action.payload.password
-            }
         case LOGIN:
+        case SET_USER:
             return {
                 ...state,
                 email: action.payload.email,
-                password: action.payload.password
+                firstName: action.payload.firstName || null,
+                lastName: action.payload.lastName || null,
+                // Never store password in Redux state for security
             }
+        case LOGOUT:
+            return null;
         default:
             return state;
     }

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -1,5 +1,16 @@
 import axios from 'axios';
 
+export const getCurrentUser = () => {
+  return axios.get('/api/user/current')
+    .then((response) => {
+      return response.data;
+    })
+    .catch((error) => {
+      console.error('Get current user error:', error.response?.data || error.message);
+      return null;
+    });
+}
+
 export const userSignUp = user => {
   return axios.post('/signup', user)
     .then((response) => {

--- a/config/passport.js
+++ b/config/passport.js
@@ -80,6 +80,8 @@ module.exports = (passport, user) => {
                         // as it posed a security vulnerability. Logged-in users are now
                         // prevented from accessing the signup endpoint in routes.js
                         const newUser = User.build({
+                            firstName: req.body.firstName,
+                            lastName: req.body.lastName,
                             localemail: email,
                             localpassword: hashedPassword
                         });

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -21,6 +21,32 @@ const authValidationRules = [
         .withMessage('Password must be at least 6 characters long')
 ];
 
+// Validation rules for signup (includes optional first and last name)
+const signupValidationRules = [
+    body('firstName')
+        .optional({ checkFalsy: true })
+        .trim()
+        .isLength({ max: 50 })
+        .withMessage('First name must not exceed 50 characters'),
+    body('lastName')
+        .optional({ checkFalsy: true })
+        .trim()
+        .isLength({ max: 50 })
+        .withMessage('Last name must not exceed 50 characters'),
+    body('email')
+        .trim()
+        .notEmpty()
+        .withMessage('Email is required')
+        .isEmail()
+        .withMessage('Must be a valid email address')
+        .normalizeEmail(),
+    body('password')
+        .notEmpty()
+        .withMessage('Password is required')
+        .isLength({ min: 6 })
+        .withMessage('Password must be at least 6 characters long')
+];
+
 // Middleware to check validation results
 const validateRequest = (req, res, next) => {
     const errors = validationResult(req);
@@ -40,6 +66,7 @@ const validateRequest = (req, res, next) => {
 
 module.exports = {
     authValidationRules,
+    signupValidationRules,
     validateRequest
 };
 

--- a/migrations/20240608000000-add-name-fields-to-users.js
+++ b/migrations/20240608000000-add-name-fields-to-users.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'firstName', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      defaultValue: null
+    });
+
+    await queryInterface.addColumn('Users', 'lastName', {
+      type: Sequelize.STRING,
+      allowNull: true,
+      defaultValue: null
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Users', 'firstName');
+    await queryInterface.removeColumn('Users', 'lastName');
+  }
+};
+

--- a/models/User.js
+++ b/models/User.js
@@ -6,6 +6,20 @@ module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define(
       'User',
       {
+        firstName: {
+          type: DataTypes.STRING,
+          allowNull: true,
+          validate: {
+            len: [0, 50]
+          }
+        },
+        lastName: {
+          type: DataTypes.STRING,
+          allowNull: true,
+          validate: {
+            len: [0, 50]
+          }
+        },
         localemail: {
           type: DataTypes.STRING,
           allowNull: false,

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -1,7 +1,22 @@
 const axios = require('axios');
-const { authValidationRules, validateRequest } = require('../middleware/validation');
+const { authValidationRules, signupValidationRules, validateRequest } = require('../middleware/validation');
 
 module.exports = (app, passport) => {
+  // Get current logged-in user
+  app.get('/api/user/current', (req, res) => {
+    if (req.user) {
+      // Only send safe user data (no password)
+      res.json({
+        id: req.user.id,
+        email: req.user.localemail,
+        firstName: req.user.firstName,
+        lastName: req.user.lastName
+      });
+    } else {
+      res.status(401).json({ error: 'Not authenticated' });
+    }
+  });
+
   // PROFILE SECTION =========================
   app.get('/dashboard', isLoggedIn, (req, res) => {
     req.user ? res.send(true) : res.send(false)
@@ -39,7 +54,7 @@ module.exports = (app, passport) => {
 
   // SIGNUP =================================
   // Process the signup form
-  app.post('/signup', authValidationRules, validateRequest, (req, res, next) => {
+  app.post('/signup', signupValidationRules, validateRequest, (req, res, next) => {
     // Security: Prevent logged-in users from using signup to change credentials
     if (req.user) {
       return res.status(403).json({


### PR DESCRIPTION
### **Story**
As a user, I want to optionally provide my first and last name during signup or from my profile settings so that HotSpotr can personalize my experience and display my name instead of my email address.

### **Background**
The Users table previously only stored localemail and localpassword. The sidebar displayed Welcome, {email} which was functional but impersonal. This PR adds optional firstName and lastName fields to the Users model and updates the signup flow and sidebar to use them.

### **Changes**
models/User.js

Added firstName and lastName as DataTypes.STRING, allowNull: true

config/passport.js

Updated local-signup strategy to optionally read firstName and lastName from req.body and store on the new user record

client/src/components/AuthModal.js

Added optional first name and last name inputs to the signup form
Fields are clearly marked as optional in the UI

client/src/components/Sidebar.js

Updated welcome message logic: user?.firstName ?? user?.email ?? 'Guest'
Displays first name if set, falls back to email, then Guest


### **Acceptance Criteria**
 firstName and lastName are optional — signup works without them
 Fields can be set during signup
 Sidebar displays Welcome, {firstName} if first name is set, falls back to email
 Fields are stored in the Users table and returned in the session user object
 Empty strings treated the same as null — fallback to email display

### **Database**
Column additions to Users table:
```
firstName  VARCHAR(255)  NULL
lastName   VARCHAR(255)  NULL
```
Migration applied via db.sequelize.sync({ alter: true }) — reverted to sync() after columns are added.

### **Notes**
No breaking changes to existing users — both fields default to null
PATCH /auth/profile endpoint for post-signup name updates is out of scope — tracked separately