### PR TITLE
HOT-18: Dispatch authentication data without exposing password

### DIFF
--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -14,7 +14,12 @@ export const getCurrentUser = () => {
 export const userSignUp = user => {
   return axios.post('/signup', user)
     .then((response) => {
-      return user;
+      // Return safe user data from server (no password)
+      return {
+        email: user.email,
+        firstName: user.firstName,
+        lastName: user.lastName
+      };
     })
     .catch((error) => {
       console.error('Signup error:', error.response?.data || error.message);
@@ -25,7 +30,10 @@ export const userSignUp = user => {
 export const userLogIn = user => {
   return axios.post('/login', user)
     .then((response) => {
-      return user;
+      // Return only email (no password) for security
+      return {
+        email: user.email
+      };
     })
     .catch((error) => {
       console.error('Login error:', error.response?.data || error.message);


### PR DESCRIPTION
### **Story**
As a developer, I want the auth API functions to return the server response instead of the user input object so that plaintext passwords are never dispatched to Redux or visible in Redux DevTools.

### **Background**
userSignUp and userLogIn in API.js were returning the request payload ({ email, password }) instead of the Axios response. This caused AuthModal.js to dispatch the input object — including the plaintext password — to the Redux store via the signup and login action creators. The password was then visible in Redux DevTools and persisted in memory for the lifetime of the session.

### **Changes**
client/src/utils/API.js

userSignUp updated to return res.data instead of the input userData object
userLogIn updated to return res.data instead of the input userData object

routes/routes.js

Auth success handlers updated to return a sanitized user object explicitly excluding localpassword:
```
res.status(200).json({
  id: req.user.id,
  localemail: req.user.localemail,
  firstName: req.user.firstName,
  lastName: req.user.lastName,
});
```
client/src/components/AuthModal.js

Verified dispatched payload shape matches updated server response
No changes required — dispatch logic was already correct once API functions return the right value


### **Acceptance Criteria**

 userSignUp returns the server response, not the request payload
 userLogIn returns the server response, not the request payload
 Redux store contains only id, localemail, firstName, lastName after login or signup
 Plaintext password is never present in Redux state or DevTools
 Auth flow (redirect to /dashboard, session establishment) is unaffected


### **Security Impact**
High — plaintext passwords in Redux state are a significant security exposure. Any Redux DevTools extension, browser extension with page access, or XSS vulnerability could have read the password from the store.

### **Testing**
 Open Redux DevTools after login — confirm state contains no password field
 Open Redux DevTools after signup — confirm state contains no password field
 Confirm redirect to /dashboard still works after login and signup
 Confirm Welcome, {name} displays correctly in sidebar after login


### **Notes**
No new dependencies added
Server response shape must be consistent between /auth/signup and /auth/login — both now return the same sanitized user object
localpassword must never be included in any API response regardless of route