### PR TITLE
HOT-19: Explicitly set DB password field characters to 60 characters

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -29,7 +29,7 @@ module.exports = (sequelize, DataTypes) => {
           }
         },
         localpassword: {
-          type: DataTypes.STRING,
+          type: DataTypes.STRING(60), // Bcrypt hashes are exactly 60 characters
           allowNull: false
         }
       },


### PR DESCRIPTION
### **Story**
As a developer, I want the localpassword column to be explicitly defined as VARCHAR(60) so that the database schema accurately reflects the fixed-length output of bcrypt and follows best practices for column sizing.

### **Background**
localpassword was defined as DataTypes.STRING which Sequelize maps to VARCHAR(255) by default. bcryptjs always produces a hash of exactly 60 characters regardless of input length. Using VARCHAR(255) wasted 195 bytes per row and obscured intent — a developer reading the schema had no indication the column holds a bcrypt hash. DataTypes.STRING(60) makes the constraint self-documenting.

### **Changes**
models/User.js
```
// before
localpassword: {
  type: DataTypes.STRING,
  allowNull: false
}

// after
localpassword: {
  type: DataTypes.STRING(60),
  allowNull: false
}
```
### **Database**

Users.localpassword column altered from VARCHAR(255) to VARCHAR(60)
Applied via DBeaver:
`ALTER TABLE Users MODIFY COLUMN localpassword VARCHAR(60) NOT NULL;`
Acceptance Criteria

 localpassword is defined as DataTypes.STRING(60) in models/User.js
 Database column is VARCHAR(60)
 Existing bcrypt hashes are unaffected
 Signup and login continue to work correctly


### **Testing**

 Signup with a new account — hash stored correctly in VARCHAR(60) column
 Login with an existing account — validPassword comparison works correctly
 Confirm column type in DBeaver — VARCHAR(60) on Users.localpassword


### **Notes**

bcrypt hash length is fixed at 60 characters for all cost factors — this constraint will never need to increase for bcrypt
CHAR(60) would be marginally more efficient since the length is always exactly 60, but VARCHAR(60) is more conventional with Sequelize and the difference is negligible at this scale
If the hashing algorithm is ever changed (e.g. Argon2), this column definition will need to be revisited as Argon2 hashes are longer