### PR TITLE
HOT-21: Prevent authenticated users from accessing signup flow

### DIFF
--- a/client/src/components/AuthModal.js
+++ b/client/src/components/AuthModal.js
@@ -74,10 +74,12 @@ export const AuthModal = ({ clickedButton, activeModal, toggleModal }) => {
           toggleModal();
         } catch (err) {
           console.error(`${clickedButton} error:`, err);
+          // Show the specific error message from the server if available
+          const errorMessage = err.response?.data?.message || err.response?.data?.error;
           setError(
-              clickedButton === 'Sign Up'
+              errorMessage || (clickedButton === 'Sign Up'
                   ? 'Signup failed. Please try again.'
-                  : 'Login failed. Please check your credentials.'
+                  : 'Login failed. Please check your credentials.')
           );
         }
     };

--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -1,20 +1,32 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Box, Typography, useTheme } from '@mui/material';
 import { Logo } from '../components/Logo.js';
 import { LargeButton } from '../components/LargeButton.js';
 import { AuthModal } from '../components/AuthModal.js';
 import { Footer } from '../components/Footer.js';
 import { SocialMedia } from '../components/SocialMedia.js';
+import { getCurrentUser } from '../utils/API.js';
 
 const BG_IMAGE = 'https://res.cloudinary.com/willblake01/image/upload/v1538510016/hotspotr/landing-background.jpg';
 
 export const Landing = () => {
   const theme = useTheme();
+  const navigate = useNavigate();
 
   const WHITE = theme.custom.white;
 
   const [activeModal, setActiveModal] = useState(false);
   const [clickedButton, setClickedButton] = useState('');
+
+  // Redirect to dashboard if already logged in
+  useEffect(() => {
+    getCurrentUser().then((user) => {
+      if (user) {
+        navigate('/dashboard', { replace: true });
+      }
+    });
+  }, [navigate]);
 
   const toggleModal  = () => setActiveModal(prev => !prev);
   const toggleSignUp = () => { setActiveModal(true); setClickedButton('Sign Up'); };

--- a/test/test.js
+++ b/test/test.js
@@ -54,10 +54,24 @@ describe('Authentication Validation', function() {
     });
 
     it('should reject signup attempt when already logged in', function(done) {
-      // This test simulates the security fix - preventing credential changes via signup
-      // In a real scenario, req.user would be set by passport after login
-      // For now, we're just documenting the expected behavior
-      // A full integration test would require creating a user, logging in, then attempting signup
+      // Security Test: Prevent logged-in users from creating new accounts
+      // This prevents an attack vector where a logged-in user's session could be
+      // hijacked to create unauthorized accounts or change credentials.
+
+      // Expected behavior:
+      // 1. Server checks req.user before processing signup
+      // 2. If req.user exists, returns 403 with specific error message
+      // 3. Client shows the server's error message to the user
+      // 4. Landing page redirects authenticated users to dashboard
+
+      // To implement a full integration test:
+      // - Create a test user
+      // - Login to establish session
+      // - Attempt signup with session cookie
+      // - Verify 403 response with correct error message
+
+      // Note: This test is a placeholder for now. Full integration testing
+      // would require session management setup with supertest.
       done();
     });
   });


### PR DESCRIPTION
[Jira HOT-21](https://hotspotr.atlassian.net/browse/HOT-21?atlOrigin=eyJpIjoiOGNjNjMyYmQxNjNjNDNmZTlhYWRiMDgwMzFhODEzNmMiLCJwIjoiaiJ9)

### **Story**
As a security-conscious developer, I want to prevent authenticated users from accessing the signup flow so that sessions cannot be used to create unauthorized accounts and users cannot accidentally create multiple accounts while logged in.

### **Background**
The previous implementation allowed a logged-in user to link a new local account to their existing session via the signup endpoint. This has been removed as it posed a credential hijacking risk — an authenticated session could be used to create and link unauthorized accounts. This ticket implements defense-in-depth protection at both the client and server layers, with clear UX messaging to guide users who encounter the restriction.

### **Acceptance Criteria**

 Authenticated user visiting / is automatically redirected to /dashboard
 Signup button is never visible to an authenticated user
 Direct POST /auth/signup call with an active session returns 403 with a clear error message
 No user record is created when a 403 is returned
 Client displays the server's error message rather than a generic fallback
 Unauthenticated signup flow is unaffected


### **Technical Notes**
Server-side guard in routes/routes.js:
```
authRouter.post('/signup', (req, res, next) => {
  if (req.user) {
    return res.status(403).json({
      message: 'You are already logged in. Please log out before creating a new account.'
    });
  }
  next();
}, passport.authenticate('local-signup', { ... }));
```
Client-side guard in Landing.js:
```
// On mount, check auth status and redirect if already logged in
const user = useSelector((state) => state.user);

useEffect(() => {
  if (user) navigate('/', { replace: true });
}, [user, navigate]);
```
Or call /auth/status on mount and redirect if a session exists:
```
useEffect(() => {
  getAuthStatus().then(({ user }) => {
    if (user) navigate('/dashboard', { replace: true });
  });
}, []);
```
Error handling in AuthModal.js:
```
// Surface server error message instead of generic fallback
} catch (err) {
  setError(err.response?.data?.message || 'Signup failed. Please try again.');
}
```
### **Security Benefits**

Prevents credential hijacking via authenticated session
Prevents accidental multi-account creation
Defense in depth — protection at both client and server layers
Clear UX — users are told to log out first rather than seeing a generic error


### **Files**

routes/routes.js — add req.user check before passport.authenticate('local-signup')
client/src/pages/Landing.js — redirect authenticated users to /dashboard on mount
client/src/components/AuthModal.js — surface server error message in catch block


### **Out of Scope**

Account merging or linking (future feature if needed)
Admin-created accounts
OAuth signup flow