### PR TITLE
HOT-7: Implement protected route component and bump react router to v7

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,7 +20,7 @@
         "react-dom": "^18.3.1",
         "react-map-gl": "^7.1.7",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^6.27.0",
+        "react-router": "^7.17.0",
         "react-scripts": "5.0.1",
         "react-transition-group": "^4.4.5",
         "redux": "^5.0.1"
@@ -3829,15 +3829,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15085,35 +15076,38 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
       },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-scripts": {
@@ -16120,6 +16114,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -10,26 +10,26 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
-    "@mui/material": "^5.16.7",
-    "@mui/icons-material": "^5.16.7",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^5.16.7",
+    "@mui/material": "^5.16.7",
+    "@redux-devtools/extension": "^3.3.0",
+    "@reduxjs/toolkit": "^2.3.0",
     "axios": "^1.7.9",
     "mapbox-gl": "^3.8.0",
-    "react-map-gl": "^7.1.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-map-gl": "^7.1.7",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.27.0",
+    "react-router": "^7.17.0",
     "react-scripts": "5.0.1",
     "react-transition-group": "^4.4.5",
-    "redux": "^5.0.1",
-    "@reduxjs/toolkit": "^2.3.0",
-    "@redux-devtools/extension": "^3.3.0"
+    "redux": "^5.0.1"
   },
   "devDependencies": {
-    "@testing-library/react": "^16.0.0",
     "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2"
   },
   "browserslist": {

--- a/client/src/components/AuthModal.js
+++ b/client/src/components/AuthModal.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { userSignUp, userLogIn } from '../utils/API';
 import { signup, login } from '../actions/actionCreators';
 import {

--- a/client/src/components/Router.js
+++ b/client/src/components/Router.js
@@ -1,18 +1,52 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import React, { useEffect } from 'react';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
 import { store } from '../configureStore';
 import { Landing } from '../pages/Landing';
 import { Dashboard } from '../pages/Dashboard';
+import { getAuthStatus } from '../utils/API';
+import { login } from '../actions/actionCreators';
+
+// Checks Redux auth state and redirects unauthenticated users to /
+// Must be used to wrap any route that requires authentication
+const ProtectedRoute = ({ children }) => {
+    const user = useSelector((state) => state.user);
+    if (!user) return <Navigate to='/' replace />;
+    return children;
+};
+
+// Separate component so useDispatch can access the Provider store above it
+const AppRoutes = () => {
+    const dispatch = useDispatch();
+
+    // Rehydrate Redux auth state from server session on page refresh.
+    // Without this, a logged-in user who refreshes the page will have
+    // state.user = null and be redirected to / by ProtectedRoute.
+    useEffect(() => {
+        getAuthStatus().then(({ user }) => {
+            if (user) dispatch(login(user));
+        });
+    }, [dispatch]);
+
+    return (
+        <Routes>
+            <Route path='/' element={<Landing />} />
+            <Route
+                path='/dashboard'
+                element={
+                    <ProtectedRoute>
+                        <Dashboard />
+                    </ProtectedRoute>
+                }
+            />
+        </Routes>
+    );
+};
 
 export const Router = () => (
     <Provider store={store}>
         <BrowserRouter>
-            <Routes>
-                {/* v6: `component` prop replaced by `element` which takes a JSX element */}
-                <Route path='/' element={<Landing />} />
-                <Route path='/dashboard' element={<Dashboard />} />
-            </Routes>
+            <AppRoutes />
         </BrowserRouter>
     </Provider>
 );

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTheme } from '@mui/material'
 import { Sidebar } from '../components/Sidebar.js';
 import { SocialMedia } from '../components/SocialMedia.js';

--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Box, Typography, useTheme } from '@mui/material';
 import { Logo } from '../components/Logo.js';
 import { LargeButton } from '../components/LargeButton.js';

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -49,3 +49,6 @@ export const userLogOut = () => {
 export const sendTest = keyword => {
   return axios.post('/api/call', keyword);
 }
+
+export const getAuthStatus = () =>
+    axios.get('/auth/status').then((res) => res.data);


### PR DESCRIPTION
### **Story**
As an authenticated user, I want protected routes to verify my session before rendering so that unauthenticated users cannot access the dashboard or any other private pages directly via URL.

### **Background**
/dashboard is currently accessible without authentication — an unauthenticated user can navigate directly to the URL and the page renders with no user in session. ProtectedRoute is a wrapper component that reads Redux auth state and redirects unauthenticated users to / before the protected page renders. It depends on getAuthStatus being called on app mount (AUTH-5) to rehydrate Redux from an active server session, preventing false redirects on page refresh.

### **Acceptance Criteria**

 ProtectedRoute component is implemented in Router.js
 Unauthenticated user navigating to /dashboard is redirected to /
 Authenticated user navigating to /dashboard is not redirected
 Logged-in user who refreshes /dashboard is not redirected to /
 ProtectedRoute is reusable — any future protected route can be wrapped with it
 / route remains publicly accessible


### **Technical Notes**
React Router v7 migration:
```
npm uninstall react-router-dom
npm install react-router@latest
```
Update all imports:
```
// before
import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';

// after
import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
```

ProtectedRoute must be defined inside a child component of <Provider> so useSelector has access to the Redux store. Placing it in the root Router component directly will throw a "could not find react-redux context" error. The solution is a separate AppRoutes component:
```
import React, { useEffect } from 'react';
import { Provider, useDispatch, useSelector } from 'react-redux';
import { BrowserRouter, Routes, Route, Navigate } from 'react-router';
import { store } from '../configureStore';
import { Landing } from '../pages/Landing';
import { Dashboard } from '../pages/Dashboard';
import { getAuthStatus } from '../utils/API';
import { login } from '../actions/actionCreators';

const ProtectedRoute = ({ children }) => {
  const user = useSelector((state) => state.user);
  if (!user) return <Navigate to='/' replace />;
  return children;
};

const AppRoutes = () => {
  const dispatch = useDispatch();

  // Rehydrate Redux auth state from server session on page refresh
  useEffect(() => {
    getAuthStatus().then(({ user }) => {
      if (user) dispatch(login(user));
    });
  }, [dispatch]);

  return (
    <Routes>
      <Route path='/' element={<Landing />} />
      <Route
        path='/dashboard'
        element={
          <ProtectedRoute>
            <Dashboard />
          </ProtectedRoute>
        }
      />
    </Routes>
  );
};

export const Router = () => (
  <Provider store={store}>
    <BrowserRouter>
      <AppRoutes />
    </BrowserRouter>
  </Provider>
);
```
<Navigate replace /> is used instead of <Navigate /> to prevent the protected route from sitting in browser history — the back button should not return to a page the user cannot access.

### **Files**

client/src/components/Router.js — add ProtectedRoute and AppRoutes components


### **Dependencies**

Requires AUTH-5 (getAuthStatus) — ProtectedRoute will incorrectly redirect authenticated users on page refresh without session rehydration
Requires react-router@7 — imports from react-router, not react-router-dom


### **Out of Scope**

Role-based access control
Redirect back to originally requested URL after login
Route-level code splitting