### PR TITLE
HOT-24: Update /dashboard map to user's location

### DIFF
--- a/client/src/components/Maps.js
+++ b/client/src/components/Maps.js
@@ -77,7 +77,7 @@ export const Maps = ({
           <Marker
               latitude={center.lat}
               longitude={center.lng}
-              onMouseEnter={() => handleMarkerEnter({ lat: center.lat, lng: center.lng, text: 'Austin, Texas' })}
+              onMouseEnter={() => handleMarkerEnter({ lat: center.lat, lng: center.lng, text: 'Your Location' })}
               onMouseLeave={handleMarkerLeave}
           />
 

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -30,6 +30,7 @@ export const Dashboard = () => {
   const [placesResults, setPlacesResults] = useState([]);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [userLocation, setUserLocation] = useState({ lat: 30.27, lng: -97.74 }); // Default to Austin, TX
 
   // Fetch current user on mount and redirect if not authenticated
   useEffect(() => {
@@ -44,6 +45,24 @@ export const Dashboard = () => {
       setIsLoading(false);
     });
   }, [dispatch, navigate]);
+
+  // Get user's current geolocation
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          setUserLocation({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+          });
+        },
+        (error) => {
+          console.warn('Geolocation error:', error.message);
+          // Keep default location (Austin, TX) if geolocation fails
+        }
+      );
+    }
+  }, []);
 
   const handleClose = () => setOpen(false);
 
@@ -180,7 +199,7 @@ export const Dashboard = () => {
           }}>
             {/* .dashboard-map: top offset to clear the header */}
             <Box sx={{ position: 'relative', top: '11vh', width: '100%' }}>
-              <Maps mapClass='dashboard-map' placesResults={placesResults} />
+              <Maps mapClass='dashboard-map' center={userLocation} placesResults={placesResults} />
             </Box>
 
             {/* .column-2-footer */}


### PR DESCRIPTION
### **Story**
As a user, I want the dashboard map to automatically center on my current location when I open the dashboard so that I can immediately start analyzing the area most relevant to me without having to manually search for it.

### **Background**
The map currently defaults to a hardcoded center of Austin, Texas (lat: 30.27, lng: -97.74). While Austin is the app's origin city, most users will be in a different location. Using the browser's Geolocation API to detect the user's position and center the map on mount creates a more relevant and personalized first impression before the user performs their first explicit search.

### **Acceptance Criteria**

 On dashboard load, the browser requests the user's geolocation
 If permission is granted, the map centers on the user's current coordinates
 If permission is denied or unavailable, the map falls back to the default center (Austin, TX)
 A loading state is shown on the map while geolocation is resolving
 User is not re-prompted on subsequent visits if permission was previously granted
 Geolocation request does not block the map from rendering — map renders immediately with default center, then flies to user location once resolved
 If the user performs a manual search, that location takes precedence over the detected location


### **Technical Notes**
```
Use the browser's native navigator.geolocation.getCurrentPosition API — no additional library needed:
// client/src/components/Maps.js
useEffect(() => {
  if (!navigator.geolocation) return; // browser doesn't support geolocation

  navigator.geolocation.getCurrentPosition(
    (position) => {
      const { latitude, longitude } = position.coords;
      dispatch(setLocation({
        lat: latitude,
        lng: longitude,
        placeName: 'Your Location',
        query: 'current-location',
      }));
    },
    (err) => {
      // Permission denied or unavailable — silently fall back to default
      console.warn('Geolocation unavailable:', err.message);
    },
    { timeout: 5000, maximumAge: 60000 }  // 5s timeout, cache position for 1 min
  );
}, []); // run once on mount
```
maximumAge: 60000 — accepts a cached position up to 1 minute old, avoiding a new GPS fix on every mount which is slow on mobile.
timeout: 5000 — if the browser takes longer than 5 seconds to resolve position, fall back silently rather than leaving the user waiting.
Geolocation should not be saved to session search history — it's a system-initiated location, not a user search. Add a guard in the history POST logic:
```
// Skip saving to history if query is 'current-location'
if (query !== 'current-location') {
  // POST /api/search/history
}
```
### **Browser Support**
navigator.geolocation is supported in all modern browsers over HTTPS. In development over HTTP it may be blocked by Chrome — test on localhost which is exempt from the HTTPS requirement.

### **Files**

client/src/components/Maps.js — add geolocation useEffect on mount
client/src/store/locationSlice.js — no changes needed, setLocation already accepts the payload shape


### **Dependencies**

Requires locationSlice to be implemented (Location Search epic)
No new npm dependencies — uses native browser API


### **Out of Scope**

Continuous location tracking (watchPosition)
Displaying the user's location as a persistent marker
Reverse geocoding the coordinates to a place name