### PR TITLE
HOT-30: Fix flash when refreshing landing page logged out

### DIFF
--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -10,7 +10,7 @@ import { ProgressBar } from './ProgressBar';
 import { userLogOut } from '../utils/API';
 import { logout } from '../actions/actionCreators';
 
-export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap }) => {
+export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap, navigate }) => {
     const theme = useTheme();
 
     const ORANGE = theme.palette.primary.main;
@@ -66,9 +66,21 @@ export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleTogg
     userLogOut()
       .then(() => {
         dispatch(logout());
-        window.location.href = '/';
+        if (navigate) {
+          navigate('/', { replace: true });
+        } else {
+          window.location.href = '/';
+        }
       })
-      .catch((err) => console.error('Logout error:', err));
+      .catch((err) => {
+        console.error('Logout error:', err);
+        // On error, still try to navigate away
+        if (navigate) {
+          navigate('/', { replace: true });
+        } else {
+          window.location.href = '/';
+        }
+      });
   };
 
   // Get display name for welcome message

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -34,14 +34,18 @@ export const Dashboard = () => {
 
   // Fetch current user on mount and redirect if not authenticated
   useEffect(() => {
-    getAuthStatus().then((user) => {
-      if (user) {
-        dispatch(login(user));
+    getAuthStatus().then((response) => {
+      if (response?.user) {
+        dispatch(login(response.user));
         setIsAuthenticated(true);
       } else {
         // User is not authenticated, redirect to landing page
         navigate('/', { replace: true });
       }
+      setIsLoading(false);
+    }).catch(() => {
+      // On error, redirect to landing page
+      navigate('/', { replace: true });
       setIsLoading(false);
     });
   }, [dispatch, navigate]);
@@ -64,7 +68,7 @@ export const Dashboard = () => {
         }
       );
     }
-  }, []);
+  }, [dispatch]);
 
   const handleClose = () => setOpen(false);
 
@@ -172,6 +176,7 @@ export const Dashboard = () => {
                 handleToggleLocation={handleToggleLocation}
                 handleToggleDemographic={handleToggleDemographic}
                 handleToggleHeatmap={handleToggleHeatmap}
+                navigate={navigate}
             />
 
             <Drawer open={open} onClose={handleClose}>

--- a/client/src/pages/Landing.js
+++ b/client/src/pages/Landing.js
@@ -18,19 +18,28 @@ export const Landing = () => {
 
   const [activeModal, setActiveModal] = useState(false);
   const [clickedButton, setClickedButton] = useState('');
+  const [isCheckingAuth, setIsCheckingAuth] = useState(true);
 
   // Redirect to dashboard if already logged in
   useEffect(() => {
-    getAuthStatus().then((user) => {
-      if (user) {
+    getAuthStatus().then((response) => {
+      if (response?.user) {
         navigate('/dashboard', { replace: true });
       }
+      setIsCheckingAuth(false);
+    }).catch(() => {
+      setIsCheckingAuth(false);
     });
   }, [navigate]);
 
   const toggleModal  = () => setActiveModal(prev => !prev);
   const toggleSignUp = () => { setActiveModal(true); setClickedButton('Sign Up'); };
   const toggleLogIn  = () => { setActiveModal(true); setClickedButton('Login'); };
+
+  // Don't render until auth check completes to prevent redirect flash
+  if (isCheckingAuth) {
+    return null;
+  }
 
   return (
       // .landing-cont — full viewport container with blurred background via ::before pseudo


### PR DESCRIPTION
When a logged-out user refreshes the landing page ('/'), there is a visible flash where the application briefly attempts to redirect to '/dashboard' before redirecting back to '/'. This creates a poor user experience and indicates improper authentication state handling.

### **Reproduction Steps:**

- Log out from the dashboard
- Navigate to '/' (landing page)
- Refresh the browser (F5 or Cmd+R)
- Observe the flash/flicker as the page briefly shows the dashboard URL before returning to '/'

### **Expected Behavior:**

- Landing page should remain stable during refresh
- No visible redirect flash should occur
- Authentication check should complete before any navigation decisions

### **Actual Behavior:**

- Application briefly redirects to '/dashboard' 
- Then immediately redirects back to '/' when auth check confirms user is not logged in
- Creates a visible flash/flicker in the browser

### **Root Cause**

Two issues were identified:

- Landing.js: Page renders immediately while auth check is in progress, causing premature navigation attempts
- API Response Handling: Both Landing and Dashboard components incorrectly parsed the getAuthStatus() response, which returns { user: {...} } not the user object directly

### **Solution Implemented**

Changes to client/src/pages/Landing.js:

- Added isCheckingAuth loading state
- Return null during auth check to prevent premature rendering
- Fixed getAuthStatus() response handling: response?.user instead of user
- Added error handling to ensure loading state clears on API failures

Changes to client/src/pages/Dashboard.js:

- Fixed getAuthStatus() response parsing: response?.user instead of user
- Added .catch() error handling for failed auth checks
- Fixed useEffect dependency array for geolocation hook

Changes to client/src/components/Sidebar.js:

- Updated logout to use React Router's navigate() instead of window.location.href
- Added error handling to ensure redirect occurs even if logout API fails
- Maintained backward compatibility with fallback to window.location.href

### **Files Modified**

client/src/pages/Landing.js client/src/pages/Dashboard.js client/src/components/Sidebar.js

### **Testing**

**Test Scenarios:**

- Refresh landing page while logged out - no flash
- Refresh landing page while logged in - smooth redirect to dashboard
- Logout from dashboard - redirects to landing page
- Refresh dashboard while logged in - stays on dashboard
- Refresh dashboard while logged out - redirects to landing page
- Network error handling - gracefully handles API failures

### **Additional Notes**

This fix improves overall authentication flow stability and prevents users from seeing intermediate routing states. The solution follows React best practices by:

- Properly handling async operations with loading states
- Correctly parsing API responses
- Using React Router for SPA navigation
- Including comprehensive error handling