### PR TITLE
HOT-29: Add /api/search/history server endpoints

### DIFF
--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Box, CircularProgress, IconButton, List, ListItem, ListItemButton, ListItemText, Paper, TextField } from '@mui/material';
 import HistoryIcon from '@mui/icons-material/History';
 import SearchIcon from '@mui/icons-material/Search';
-import { geocodeLocation } from '../utils/API';
+import { geocodeLocation, saveSearchHistory } from '../utils/API';
 import { setLocation } from '../store/locationSlice';
 
 export const SearchBar = () => {
@@ -23,6 +23,7 @@ export const SearchBar = () => {
         try {
             const result = await geocodeLocation(query);
             dispatch(setLocation(result));
+            await saveSearchHistory(result);  // persist to Redis session
             setQuery('');
         } catch (err) {
             setError(err.message || 'Search unavailable. Please try again.');

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -9,9 +9,9 @@ import { Maps } from '../components/Maps.js';
 import { SearchBar } from '../components/SearchBar.js';
 import { Sidebar } from '../components/Sidebar.js';
 import { SocialMedia } from '../components/SocialMedia.js';
-import { getAuthStatus } from '../utils/API';
+import { getAuthStatus, getSearchHistory } from '../utils/API';
 import { login } from '../actions/actionCreators';
-import { setLocation } from '../store/locationSlice';
+import { setLocation, setHistory } from '../store/locationSlice';
 
 const DB_BG = 'https://res.cloudinary.com/willblake01/image/upload/v1538510014/hotspotr/dashboard-background.jpg';
 
@@ -68,6 +68,13 @@ export const Dashboard = () => {
         }
       );
     }
+  }, [dispatch]);
+
+  // Fetch search history on mount
+  useEffect(() => {
+    getSearchHistory().then((history) => {
+      if (history.length > 0) dispatch(setHistory(history));
+    });
   }, [dispatch]);
 
   const handleClose = () => setOpen(false);

--- a/client/src/store/locationSlice.js
+++ b/client/src/store/locationSlice.js
@@ -23,8 +23,11 @@ const locationSlice = createSlice({
                 ...state.history
             ].slice(0, 10);
         },
+        setHistory: (state, action) => {
+            state.history = action.payload;
+        },
     },
 });
 
-export const { setLocation } = locationSlice.actions;
+export const { setLocation, setHistory } = locationSlice.actions;
 export default locationSlice.reducer;

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -41,3 +41,12 @@ export const geocodeLocation = async (query) => {
 
   return { lat, lng, bbox, placeName, query };
 };
+
+export const saveSearchHistory = (entry) =>
+    api.post('/api/search/history', entry).then(res => res.data);
+
+export const getSearchHistory = () =>
+    api.get('/api/search/history').then(res => res.data.history);
+
+export const clearSearchHistory = () =>
+    api.delete('/api/search/history').then(res => res.data);

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -95,4 +95,49 @@ module.exports = (app, passport) => {
       });
     });
   });
+
+  // =============================================================================
+  // API MIDDLEWARE =============================================================
+  // =============================================================================
+
+  const requireAuth = (req, res, next) => {
+    if (!req.isAuthenticated()) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    next();
+  };
+
+  app.use('/api', requireAuth);
+
+  // =============================================================================
+  // SEARCH HISTORY ROUTES ======================================================
+  // =============================================================================
+
+  app.post('/api/search/history', (req, res) => {
+    const { query, lat, lng, placeName, bbox } = req.body;
+
+    // Skip saving geolocation entries
+    if (query === 'current-location') {
+      return res.status(200).json({ history: req.session.searchHistory || [] });
+    }
+
+    if (!req.session.searchHistory) req.session.searchHistory = [];
+
+    // Prepend new entry, cap at 10
+    req.session.searchHistory = [
+      { query, lat, lng, placeName, bbox, timestamp: new Date().toISOString() },
+      ...req.session.searchHistory
+    ].slice(0, 10);
+
+    res.status(200).json({ history: req.session.searchHistory });
+  });
+
+  app.get('/api/search/history', (req, res) => {
+    res.status(200).json({ history: req.session.searchHistory || [] });
+  });
+
+  app.delete('/api/search/history', (req, res) => {
+    req.session.searchHistory = [];
+    res.status(200).json({ history: [] });
+  });
 };


### PR DESCRIPTION
### **Story**

As a user, I want my search history to persist across page refreshes so that my recent location searches are available when I return to the dashboard without having to search again.

### **Background**

locationSlice maintains client-side search history in Redux but this is cleared on every page refresh. Persisting history server-side in the user's Redis session via /api/search/history endpoints allows the client to rehydrate the history dropdown on mount. History is stored in req.session.searchHistory which is automatically serialized to Redis by express-session.

### **Acceptance Criteria**

-  POST /api/search/history appends a search entry to the session
-  GET /api/search/history returns the session search history array
-  DELETE /api/search/history clears the session search history
-  All three endpoints require authentication — unauthenticated requests return 401
-  History is capped at 10 entries — oldest entries are dropped when limit is reached
-  Entries with query: 'current-location' are not saved to server history
-  On dashboard mount, client fetches history from server and hydrates locationSlice
-  localpassword or any sensitive data is never stored in history entries

### **Technical Notes**
Server — routes/routes.js:

```
const requireAuth = (req, res, next) => {
  if (!req.isAuthenticated()) {
    return res.status(401).json({ error: 'Unauthorized' });
  }
  next();
};

app.use('/api', requireAuth);

app.post('/api/search/history', (req, res) => {
  const { query, lat, lng, placeName, bbox } = req.body;

  // Skip saving geolocation entries
  if (query === 'current-location') {
    return res.status(200).json({ history: req.session.searchHistory || [] });
  }

  if (!req.session.searchHistory) req.session.searchHistory = [];

  // Prepend new entry, cap at 10
  req.session.searchHistory = [
    { query, lat, lng, placeName, bbox, timestamp: new Date().toISOString() },
    ...req.session.searchHistory
  ].slice(0, 10);

  res.status(200).json({ history: req.session.searchHistory });
});

app.get('/api/search/history', (req, res) => {
  res.status(200).json({ history: req.session.searchHistory || [] });
});

app.delete('/api/search/history', (req, res) => {
  req.session.searchHistory = [];
  res.status(200).json({ history: [] });
});
```

### **Client — API.js:**

```
export const saveSearchHistory = (entry) =>
  api.post('/api/search/history', entry).then(res => res.data);

export const getSearchHistory = () =>
  api.get('/api/search/history').then(res => res.data.history);

export const clearSearchHistory = () =>
  api.delete('/api/search/history').then(res => res.data);
```

### **Client — rehydrate on dashboard mount in Dashboard.js:**

```
useEffect(() => {
  getSearchHistory().then((history) => {
    if (history.length > 0) dispatch(setHistory(history));
  });
}, [dispatch]);
```

### **Add setHistory action to locationSlice:**

```
setHistory: (state, action) => {
  state.history = action.payload;
},
```

### **Save to server after each search in SearchBar.js:**

```
const result = await geocodeLocation(query);
dispatch(setLocation(result));
await saveSearchHistory(result);  // persist to Redis session
```

### **Endpoint Contracts**
| Method | Path | Auth | Request Body | Response |
|--------|--------|--------|--------|--------|
| POST | /api/search/history | Yes | { query, lat, lng, placeName, bbox } | 200 { history: [...] } |
| GET | /api/search/history | Yes | None | 200 { history: [...] } |
| DELETE | /api/search/history | Yes | None | 200 { history: [...] } | 

### **History Entry Shape**

```
{
  "query": "Austin, TX",
  "lat": 30.2672,
  "lng": -97.7431,
  "placeName": "Austin, Texas, United States",
  "bbox": [-98.1719, 30.0987, -97.5694, 30.5968],
  "timestamp": "2026-06-13T15:00:00.000Z"
}
```

### **Files**

- routes/routes.js — add three /api/search/history endpoints and requireAuth middleware
- client/src/utils/API.js — add saveSearchHistory, getSearchHistory, clearSearchHistory
- client/src/store/locationSlice.js — add setHistory action
- client/src/components/SearchBar.js — call saveSearchHistory after successful geocode
- client/src/pages/Dashboard.js — call getSearchHistory on mount to rehydrate history


### **Dependencies**

- AUTH-3 (Redis session store) — req.session.searchHistory is persisted to Redis automatically
- LOC-2 (locationSlice) — setHistory action added to existing slice
- LOC-4 (search history dropdown) — UI that reads from state.location.history


### **Out of Scope**

- Deleting individual history entries
- Sharing search history across devices
- Caching geocoding results in Redis