### PR TITLE
HOT-35: Add Show Competitors SideBar item

### DIFF
--- a/client/src/components/Maps.js
+++ b/client/src/components/Maps.js
@@ -3,6 +3,7 @@ import Map, { Source, Layer, Marker, Popup } from 'react-map-gl';
 import { useSelector } from 'react-redux';
 import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import RoomIcon from '@mui/icons-material/Room';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 // Converts placesResults array into a GeoJSON FeatureCollection for Mapbox heatmap
@@ -51,14 +52,19 @@ const heatmapLayer = {
 };
 
 export const Maps = ({
-  placesResults = []
+    placesResults = [],
+    showCompetitors = false,
 }) => {
   const theme = useTheme();
   const mapRef = useRef(null);
+
   const [popupInfo, setPopupInfo] = useState(null);
+  const [hoveredCompetitor, setHoveredCompetitor] = useState(null);
 
   const location = useSelector((state) => state.location);
-  const { overpassData, censusData, loading, error } = useSelector((state) => state.heatmap);
+  const { censusData, loading, error } = useSelector((state) => state.heatmap);
+  const overpassData = useSelector((state) => state.heatmap.overpassData);
+  const filters = useSelector((state) => state.filters);
 
   const handleMarkerEnter = useCallback((marker) => setPopupInfo(marker), []);
   const handleMarkerLeave = useCallback(() => setPopupInfo(null), []);
@@ -69,9 +75,7 @@ export const Maps = ({
     zoom: location.zoom ?? 11
   };
 
-  const geoData = overpassData?.elements
-      ? toGeoJSON(overpassData.elements)
-      : { type: 'FeatureCollection', features: [] };
+  const geoData = { type: 'FeatureCollection', features: [] };
 
   const BROWN = theme.palette.secondary.main;
 
@@ -112,6 +116,39 @@ export const Maps = ({
               <Source id='heatmap-source' type='geojson' data={geoData}>
                 <Layer {...heatmapLayer} />
               </Source>
+          )}
+
+          {showCompetitors && overpassData?.elements?.map((el) => {
+            const lat = el.lat ?? el.center?.lat;
+            const lon = el.lon ?? el.center?.lon;
+            const name = el.tags?.name || filters.industry.label;
+            if (!lat || !lon) return null;
+            return (
+                <Marker
+                    key={el.id}
+                    latitude={lat}
+                    longitude={lon}
+                >
+                  <RoomIcon
+                      sx={{ color: '#573525', fontSize: '28px', cursor: 'pointer' }}
+                      onMouseEnter={() => setHoveredCompetitor({ lat, lon, name })}
+                      onMouseLeave={() => setHoveredCompetitor(null)}
+                  />
+                </Marker>
+            );
+          })}
+
+          {hoveredCompetitor && (
+              <Popup
+                  latitude={hoveredCompetitor.lat}
+                  longitude={hoveredCompetitor.lon}
+                  closeButton={false}
+                  anchor='top'
+              >
+                <Typography variant='body2' sx={{ color: BROWN, fontWeight: 'bold' }}>
+                  {hoveredCompetitor.name}
+                </Typography>
+              </Popup>
           )}
 
           <Marker

--- a/client/src/components/Sidebar.js
+++ b/client/src/components/Sidebar.js
@@ -3,15 +3,15 @@ import { useNavigate } from 'react-router';
 import { useSelector, useDispatch } from 'react-redux';
 import { Box, Button, Divider, Stack, Typography, useTheme } from '@mui/material';
 import BusinessIcon from '@mui/icons-material/Business';
-import LocationOnIcon from '@mui/icons-material/LocationOn';
 import GroupsIcon from '@mui/icons-material/Groups';
-import MapIcon from '@mui/icons-material/Map';
+import TuneIcon from '@mui/icons-material/Tune';
 import LogoutIcon from '@mui/icons-material/Logout';
+import StorefrontIcon from '@mui/icons-material/Storefront';
 import { ProgressBar } from './ProgressBar';
 import { userLogOut } from '../utils/API';
 import { logout } from '../actions/actionCreators';
 
-export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap }) => {
+export const Sidebar = ({ handleToggleIndustry, handleToggleRadius, handleToggleDemographics, handleToggleCompetitors }) => {
     const theme = useTheme();
     const navigate = useNavigate();
 
@@ -20,10 +20,10 @@ export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleTogg
     const WHITE  = theme.custom.white;
 
     const navItems = [
-        { label: 'TARGET INDUSTRY',     icon: <BusinessIcon />,   handler: 'handleToggleIndustry'    },
-        { label: 'LOCATION RADIUS',     icon: <LocationOnIcon />, handler: 'handleToggleLocation'    },
-        { label: 'TARGET DEMOGRAPHICS', icon: <GroupsIcon />,     handler: 'handleToggleDemographic' },
-        { label: 'COMPETITION HEATMAP', icon: <MapIcon />,        handler: 'handleToggleHeatmap'     },
+        { label: 'TARGET INDUSTRY', icon: <BusinessIcon />, handler: 'handleToggleIndustry' },
+        { label: 'LOCATION RADIUS', icon: <TuneIcon />, handler: 'handleToggleRadius' },
+        { label: 'TARGET DEMOGRAPHICS', icon: <GroupsIcon />, handler: 'handleToggleDemographics' },
+        { label: 'SHOW COMPETITORS', icon: <StorefrontIcon />, handler: 'handleToggleCompetitors' },
     ];
 
     // Shared button styles — mirrors .sidebar-link and .sidebar-link:hover
@@ -62,7 +62,7 @@ export const Sidebar = ({ handleToggleIndustry, handleToggleLocation, handleTogg
   const user = useSelector((state) => state.user);
   const dispatch = useDispatch();
 
-  const handlers = { handleToggleIndustry, handleToggleLocation, handleToggleDemographic, handleToggleHeatmap };
+  const handlers = { handleToggleIndustry, handleToggleRadius, handleToggleDemographics, handleToggleCompetitors };
 
     const handleLogOut = () => {
         userLogOut()

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -28,6 +28,7 @@ export const Dashboard = () => {
 
   const [open, setOpen] = useState(false);
   const [whichForm, setWhichForm] = useState('');
+  const [showCompetitors, setShowCompetitors] = useState(false);
 
   // Geolocation — center map on user's current position on mount
   useEffect(() => {
@@ -56,9 +57,9 @@ export const Dashboard = () => {
   const handleClose = () => setOpen(false);
 
   const handleToggleIndustry    = () => { setOpen(!open); setWhichForm('industry'); };
-  const handleToggleLocation    = () => { setOpen(!open); setWhichForm('location'); };
-  const handleToggleDemographic = () => { setOpen(!open); setWhichForm('demographic'); };
-  const handleToggleHeatmap     = () => console.log('Yolo!');
+  const handleToggleRadius    = () => { setOpen(!open); setWhichForm('location'); };
+  const handleToggleDemographics = () => { setOpen(!open); setWhichForm('demographic'); };
+  const handleToggleCompetitors = () => setShowCompetitors(prev => !prev);
 
   // Each form is self-contained — dispatches to filtersSlice directly
   // onSubmit is passed so forms can close the Drawer after submitting
@@ -137,9 +138,9 @@ export const Dashboard = () => {
           }}>
             <Sidebar
                 handleToggleIndustry={handleToggleIndustry}
-                handleToggleLocation={handleToggleLocation}
-                handleToggleDemographic={handleToggleDemographic}
-                handleToggleHeatmap={handleToggleHeatmap}
+                handleToggleRadius={handleToggleRadius}
+                handleToggleDemographics={handleToggleDemographics}
+                handleToggleCompetitors={handleToggleCompetitors}
             />
 
             <Drawer
@@ -187,7 +188,7 @@ export const Dashboard = () => {
               top: '11vh',
               width: '100%'
             }}>
-              <Maps />
+              <Maps showCompetitors={showCompetitors} />
             </Box>
             <Box sx={{
               display: 'flex',


### PR DESCRIPTION
### **Story**
As a user, I want to toggle competitor location pins on and off on the map so that I can see exactly where my competitors are located while keeping the opportunity heatmap as a separate visualization layer.

### **Background**
The sidebar "COMPETITION HEATMAP" button currently has no implementation. Rather than using it to trigger the heatmap (which renders automatically on industry selection), it is repurposed as a competitor pin toggle. The Overpass data is already in Redux from the industry selection fetch — no additional API call is needed. This creates a clean two-layer map experience: the opportunity heatmap shows where to open, the competitor pins show who is already there.

### **Acceptance Criteria**

- Sidebar button renamed from "COMPETITION HEATMAP" to "SHOW COMPETITORS"
- Clicking "SHOW COMPETITORS" toggles competitor pins on and off
- Pins are not shown until industry data has been fetched — button is visually inactive if no Overpass data exists
- Each pin renders at the correct lat/lng for both nodes and ways
- Hovering or clicking a pin opens a MUI Popup showing the competitor name
- If a competitor has no name in OSM tags, popup shows the industry label as fallback — e.g. "Coffee Shop"
- Popup closes when the user moves away from the pin
- Pins are visually distinct from the user location marker
- Toggling pins off removes all competitor markers from the map
- Competitor pins and opportunity heatmap are independent layers — toggling pins does not affect the heatmap

### **Technical Notes**

**Dashboard.js — add toggle state:**

`const handleToggleCompetitors = () => setShowCompetitors(prev => !prev);`

**Pass to Maps.js via prop or store in Redux. Local state in Dashboard.js is sufficient since it's purely a UI toggle:**

```
const [showCompetitors, setShowCompetitors] = useState(false);

<Maps showCompetitors={showCompetitors} />
```

Sidebar.js — rename button and update icon:

`{ label: 'SHOW COMPETITORS', icon: <StorefrontIcon />, handler: 'handleToggleHeatmap' }`

StorefrontIcon from @mui/icons-material/Storefront is appropriate for competitor locations.

**Maps.js — render competitor pins:**

```
const overpassData = useSelector((state) => state.heatmap.overpassData);

{showCompetitors && overpassData?.elements?.map((el) => {
  const lat = el.lat ?? el.center?.lat;
  const lon = el.lon ?? el.center?.lon;
  const name = el.tags?.name || filters.industry.label;

  if (!lat || !lon) return null;

  return (
    <Marker
      key={el.id}
      latitude={lat}
      longitude={lon}
      color='#573525'  // BROWN — distinct from user location marker
    >
      <Popup
        latitude={lat}
        longitude={lon}
        closeButton={false}
        anchor='top'
        offset={20}
      >
        <Typography variant='body2' sx={{ color: BROWN, fontWeight: 'bold' }}>
          {name}
        </Typography>
      </Popup>
    </Marker>
  );
})}
```

**Note on Popup behavior — react-map-gl Popup attached directly to a Marker renders permanently. For hover behavior use local state:**

```
const [hoveredCompetitor, setHoveredCompetitor] = useState(null);

<Marker
  key={el.id}
  latitude={lat}
  longitude={lon}
  onMouseEnter={() => setHoveredCompetitor(el)}
  onMouseLeave={() => setHoveredCompetitor(null)}
/>

{hoveredCompetitor && (
  <Popup
    latitude={hoveredCompetitor.lat ?? hoveredCompetitor.center?.lat}
    longitude={hoveredCompetitor.lon ?? hoveredCompetitor.center?.lon}
    closeButton={false}
    anchor='top'
  >
    <Typography variant='body2' sx={{ color: BROWN, fontWeight: 'bold' }}>
      {hoveredCompetitor.tags?.name || filters.industry.label}
    </Typography>
  </Popup>
)}
```

Map Layer Summary

| Layer | Trigger | Data Source | Toggle |
|--------|--------|--------|--------|
| Opportunity | Industry selection | Overpass + Census scored | Always on when data exists |
| Competitor pins | "Show Competitors" buttons | `state.heatmap.overpass` Data | User Toggle |
| User location marker | Geolocation / search | `state.location` | Always on |

**Files**

- client/src/components/Sidebar.js — rename button label and icon
- client/src/pages/Dashboard.js — add showCompetitors state and handleToggleCompetitors
- client/src/components/Maps.js — add competitor pin rendering with hover popup

**Dependencies**

- LOC-6 (data fetch orchestration) — state.heatmap.overpassData must be populated before pins can render
- LOC-8 (Industry form refactor) — filters.industry.label used as fallback pin name

**Out of Scope**

- Competitor detail panel on click
- Filtering competitors by rating or category
- Clustering pins at low zoom levels